### PR TITLE
182 banner overlap

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -20,7 +20,7 @@ export const Header = () => {
         padding=""
         className="relative z-10 my-4 max-w-9xl py-0"
       >
-        <div className="sm:flex sm:items-center sm:justify-between">
+        <div className="sm:flex sm:items-center sm:justify-between sm:gap-2">
           <Logo />
           <div className="mt-4 flex items-center justify-center sm:mt-0">
             <SocialIcons excludeMobile={excludeMobile} />
@@ -54,7 +54,7 @@ const Logo = () => {
           width={150}
         />
       </Link>
-      <div className="ml-4 w-24 text-sm font-semibold uppercase leading-4 text-gray-700">
+      <div className="ml-4 hidden w-24 text-sm font-semibold uppercase leading-4 text-gray-700 md:block">
         Enterprise Software Development
       </div>
     </h4>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Link from "next/link";
-import Image from "next/legacy/image";
+import Image from "next/image";
 import { Container } from "../util/container";
 import { SocialIcons, SocialTypes } from "../util/socialIcons";
 import { LiveStreamBanner } from "../liveStreamBanner";
@@ -46,7 +46,6 @@ const Logo = () => {
         passHref
         className="flex items-center gap-1 whitespace-nowrap"
       >
-        {/* TODO: refactor with next/image */}
         <Image
           src={logoPath}
           alt="SSW - Enterprise Software Development"

--- a/components/util/socialIcons.tsx
+++ b/components/util/socialIcons.tsx
@@ -126,7 +126,7 @@ export const SocialIcons = (data?: SocialIconsParams) => {
             className={classNames(
               "flex h-11 cursor-pointer items-center justify-center text-base hover:bg-gray-1000 hover:bg-none",
               styling.bgClassName,
-              social.linkText ? "w-fit" : "w-11",
+              social.linkText ? "w-fit shrink-0" : "w-11",
               { "px-6": social.linkText },
               { "flex sm:hidden": hideOnDesktop },
               { "hidden sm:flex": hideOnMobile },


### PR DESCRIPTION
#182 

- [x] Make header banner responsive
- [x] Tech Debt - replace `next/legacy/image` with `next/image`

![image](https://user-images.githubusercontent.com/113034339/218694405-40c744b2-0333-455f-94b7-08e89c2c4414.png)
![image](https://user-images.githubusercontent.com/113034339/218694502-dec75c96-1d31-4241-afbb-db6f3ee9b236.png)
**Figure: `<Header />` in middle size hide text**

![image](https://user-images.githubusercontent.com/113034339/218694668-aa9f330d-cd93-4573-9fa4-1b07f57d421b.png)
**Figure: `<Header/>` in small size with clear social icons**