### PR TITLE
made "CONSULTING" & "CORE SERVICES" text smaller

### DIFF
--- a/components/blocks/serviceCards.tsx
+++ b/components/blocks/serviceCards.tsx
@@ -36,7 +36,7 @@ export const ServiceCards = ({ data }) => {
 const Label = ({ text }) => {
   return (
     <div
-      className={`absolute text-left text-xs font-normal uppercase text-white ${bgColor["darkgray"]} z-10 w-fit p-2`}
+      className={`absolute text-left text-xxxs font-normal uppercase text-white ${bgColor["darkgray"]} z-10 w-fit p-2`}
     >
       {text}
     </div>


### PR DESCRIPTION
*Note: relies on styling changes pushed here: https://github.com/SSWConsulting/SSW.Website-v3/pull/209/files

- [x] Make "CONSULTING" & "CORE SERVICES" text smaller so it matches the current website

Closes #191 