### PR TITLE
"More Services"/"More Events" button styling incorrect

### DIFF
--- a/components/blocks/serviceCards.tsx
+++ b/components/blocks/serviceCards.tsx
@@ -135,7 +135,7 @@ const Links = ({ links }) => {
         <Link
           key={i}
           href={card.link ?? ""}
-          className="inline-flex items-center rounded border-1 border-gray-300 bg-white px-3 py-2 text-xs font-normal leading-4 text-black shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2"
+          className="inline-flex items-center rounded border-1 border-gray-300 bg-white px-3 py-2 text-xs font-normal leading-4 text-gray-800 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2"
         >
           {card.label}
         </Link>

--- a/components/blocks/serviceCards.tsx
+++ b/components/blocks/serviceCards.tsx
@@ -135,7 +135,7 @@ const Links = ({ links }) => {
         <Link
           key={i}
           href={card.link ?? ""}
-          className="inline-flex items-center border-2 border-gray-300 bg-white px-3 py-2 text-xs font-normal leading-4 text-black shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2"
+          className="inline-flex items-center rounded border-1 border-gray-300 bg-white px-3 py-2 text-xs font-normal leading-4 text-black shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2"
         >
           {card.label}
         </Link>

--- a/components/blocks/upcomingEvents.tsx
+++ b/components/blocks/upcomingEvents.tsx
@@ -61,7 +61,7 @@ export const UpcomingEvents = ({ data }) => {
           {/* TODO: Update link after implement this page */}
           <Link
             href="https://www.ssw.com.au/ssw/Events/?tech=all&type=all"
-            className="inline-flex items-center rounded border-1 border-gray-300 bg-white px-3 py-2 text-xs font-normal leading-4 text-black shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2"
+            className="inline-flex items-center rounded border-1 border-gray-300 bg-white px-3 py-2 text-xs font-normal leading-4 text-gray-800 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2"
           >
             More Events
           </Link>

--- a/components/blocks/upcomingEvents.tsx
+++ b/components/blocks/upcomingEvents.tsx
@@ -61,7 +61,7 @@ export const UpcomingEvents = ({ data }) => {
           {/* TODO: Update link after implement this page */}
           <Link
             href="https://www.ssw.com.au/ssw/Events/?tech=all&type=all"
-            className="inline-flex items-center border-2 border-gray-300 bg-white px-3 py-2 text-xs font-normal leading-4 text-black shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2"
+            className="inline-flex items-center rounded border-1 border-gray-300 bg-white px-3 py-2 text-xs font-normal leading-4 text-black shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2"
           >
             More Events
           </Link>


### PR DESCRIPTION
- [x] Fix the "More Services"/"More Events" to be more inline with the current website styling

![image](https://user-images.githubusercontent.com/25432120/219524645-a848e1a2-0385-4365-86f3-6b1fdc0300ca.png)
**Figure: New implementation**

![image](https://user-images.githubusercontent.com/25432120/219524678-d2364e8f-e38a-42f9-a2d4-d9a72e28be5c.png)
**Figure: Current site**

Closes #205 