### PR TITLE
💄 Technology cards UI review round 2

### DIFF
--- a/components/technologyCard/technologyCard.module.css
+++ b/components/technologyCard/technologyCard.module.css
@@ -1,5 +1,5 @@
 .technology-card p {
-  @apply mx-auto my-auto w-9/12 px-0 py-5 text-justify font-sans text-md font-light;
+  @apply mx-auto my-auto w-9/12 px-0 py-5 text-center font-sans text-md font-light;
 }
 .technology-card p a {
   @apply ml-4 font-body;

--- a/components/technologyCard/technologyCard.tsx
+++ b/components/technologyCard/technologyCard.tsx
@@ -12,9 +12,10 @@ const TechnologyCard: FC<TechnologyCardProps> = ({
   readMoreSlug,
   thumbnail,
   body,
+  className,
 }) => {
   return (
-    <div className="col-span-12 md:col-span-6">
+    <div className={`col-span-12 ${className ?? ""}`}>
       <article
         className={classnames([
           styles["technology-card"],

--- a/components/technologyCard/technologyCard.tsx
+++ b/components/technologyCard/technologyCard.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { VFC } from "react";
+import { FC } from "react";
 import { BASE_URL } from "../util/constants";
 import { TechnologyCardProps } from "./technologyCardTypes";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
@@ -7,7 +7,7 @@ import Image from "next/image";
 import styles from "./technologyCard.module.css";
 import classnames from "classnames";
 
-const TechnologyCard: VFC<TechnologyCardProps> = ({
+const TechnologyCard: FC<TechnologyCardProps> = ({
   name,
   readMoreSlug,
   thumbnail,
@@ -22,8 +22,7 @@ const TechnologyCard: VFC<TechnologyCardProps> = ({
         ])}
         data-aos="flip-left"
       >
-        {
-          thumbnail &&
+        {thumbnail && (
           <figure className="relative h-24">
             <Image
               src={thumbnail || "/images/ssw-logo.svg"}
@@ -32,9 +31,13 @@ const TechnologyCard: VFC<TechnologyCardProps> = ({
               objectFit="contain"
             ></Image>
           </figure>
-        }
+        )}
         <TinaMarkdown content={body} />
-        {readMoreSlug && <Link href={BASE_URL + readMoreSlug}>Read More</Link>}
+        {readMoreSlug && (
+          <Link className="text-md" href={BASE_URL + readMoreSlug}>
+            Read More
+          </Link>
+        )}
       </article>
     </div>
   );

--- a/components/technologyCard/technologyCard.tsx
+++ b/components/technologyCard/technologyCard.tsx
@@ -28,7 +28,7 @@ const TechnologyCard: FC<TechnologyCardProps> = ({
               src={thumbnail || "/images/ssw-logo.svg"}
               alt={thumbnail ? name : "SSW Consulting"}
               fill
-              objectFit="contain"
+              className="object-contain"
             ></Image>
           </figure>
         )}

--- a/components/technologyCard/technologyCardTypes.ts
+++ b/components/technologyCard/technologyCardTypes.ts
@@ -3,6 +3,7 @@ export type TechnologyCardProps = {
   readMoreSlug?: string | null;
   thumbnail?: string | null;
   body?: any | null; // eslint-disable-line @typescript-eslint/no-explicit-any
+  className?: string;
 };
 
 export type TechnologyCardsProps = {

--- a/components/technologyCard/technologyCardTypes.ts
+++ b/components/technologyCard/technologyCardTypes.ts
@@ -1,7 +1,5 @@
 export type TechnologyCardProps = {
-  index: number;
   name: string;
-  techListLength: number;
   readMoreSlug?: string | null;
   thumbnail?: string | null;
   body?: any | null; // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/components/technologyCard/technologyCards.tsx
+++ b/components/technologyCard/technologyCards.tsx
@@ -6,12 +6,27 @@ const TechnologyCards: FC<TechnologyCardsProps> = ({
   techHeader,
   techCards,
 }) => {
+  const isOdd = !!(techCards.length % 2);
+
   return (
     <article className="bg-white text-black">
       <h1 className="mt-0">{techHeader}</h1>
       <div className="grid grid-cols-12 gap-y-10">
-        {techCards.map((card) => {
-          return <TechnologyCard key={card.name} {...card} />;
+        {techCards.map((card, idx) => {
+          const isLast = () => idx == techCards.length - 1;
+          return isOdd && isLast() ? (
+            <TechnologyCard
+              key={card.name}
+              className="md:col-span-12"
+              {...card}
+            />
+          ) : (
+            <TechnologyCard
+              key={card.name}
+              className="md:col-span-6"
+              {...card}
+            />
+          );
         })}
       </div>
     </article>

--- a/components/technologyCard/technologyCards.tsx
+++ b/components/technologyCard/technologyCards.tsx
@@ -1,41 +1,19 @@
-import { VFC, useEffect, useState } from "react";
+import { FC } from "react";
 import TechnologyCard from "./technologyCard";
 import { TechnologyCardsProps } from "./technologyCardTypes";
 
-const TechnologyCards: VFC<TechnologyCardsProps> = ({
+const TechnologyCards: FC<TechnologyCardsProps> = ({
   techHeader,
   techCards,
 }) => {
-  const [techComponents, setTechComponents] = useState([]);
-  const getComponent = (name: string, index: number) => {
-    const technologyCardNode = techCards.find((c) => c.name == name);
-    if (technologyCardNode) {
-      return (
-        <TechnologyCard
-          {...technologyCardNode}
-          index={index}
-          techListLength={techCards.length}
-          key={index}
-        />
-      );
-    } else {
-      return null;
-    }
-  };
-
-  useEffect(() => {
-    techCards.map((card, index) => {
-      setTechComponents((techComponents: Element[]) => [
-        ...techComponents,
-        getComponent(card.name, index),
-      ]);
-    });
-  }, []);
-
   return (
     <article className="bg-white text-black">
       <h1 className="mt-0">{techHeader}</h1>
-      <div className="grid grid-cols-12 gap-y-10">{techComponents}</div>
+      <div className="grid grid-cols-12 gap-y-10">
+        {techCards.map((card) => {
+          return <TechnologyCard key={card.name} {...card} />;
+        })}
+      </div>
     </article>
   );
 };


### PR DESCRIPTION
In the result of the UI review round 2, `<TechnologyCards />` have several small bugs.

I fix them together for convenience.

#197
- [x] Fix the "Read More" text size to match the rest of the surrounding text

#214
- [x] Centered text of tech cards
 
#203 
- [x] Refactor `<TechnologyCards />` and `<TechnologyCard />`
    - [x] Removed unneeded hooks
    - [x] Change type VFC to FC
    - [x] Tech debt - upgrade Nextjs 13 image
- [x] Ensure technology card spans if it's alone

---

![image](https://user-images.githubusercontent.com/113034339/219605250-ded54125-8a13-4779-a629-c4507e5615a1.png)
**Figure: #197 Enlarged "Read More" text size**

![image](https://user-images.githubusercontent.com/113034339/219605389-a0fc93bd-f381-4685-bdab-62a495653b6d.png)
**Figure: #214 Centered text of tech cards**

![image](https://user-images.githubusercontent.com/113034339/219605509-ff4f27d8-c57b-4f2d-a5ec-9a7c8ec163b1.png)
**Figure: #203 Technology card spans in odds**

