### PR TITLE
Links - css fixes

### DIFF
--- a/components/blocks/breadcrumbs.tsx
+++ b/components/blocks/breadcrumbs.tsx
@@ -4,7 +4,7 @@ import NextBreadcrumbs from "nextjs-breadcrumbs2";
 export const Breadcrumbs = (props) => {
   const listItemStyling = "breadcrumb_item inline text-xs text-gray-700 no-underline not-first:before:content-bread not-first:before:px-2 before:list-none"
   return (
-    <div>
+    <>
       <NextBreadcrumbs 
         replaceCharacterList={[
             {from: "consulting", to: "Services"},
@@ -15,6 +15,6 @@ export const Breadcrumbs = (props) => {
         activeItemClassName={listItemStyling}
         rootLabel={"Home"}
       />
-    </div>
+    </>
   );
 }

--- a/content/global/index.json
+++ b/content/global/index.json
@@ -11,7 +11,7 @@
       "thumbnailUrl": "https://i.ytimg.com/vi/2G7z2mF7Onk/maxresdefault.jpg"
     }
   },
-  "breadcrumbSuffix": "SSW Consulting - Sydney, Brisbane, Melbourne",
+  "breadcrumbSuffix": "SSW Consulting - Sydney, Brisbane, Melbourne, Newcastle",
   "bookingButtonText": "Book a FREE Initial Meeting",
   "offices": [
     {

--- a/styles.css
+++ b/styles.css
@@ -3,12 +3,13 @@
 @tailwind utilities;
 
 @layer base {
-  a {
-    transition: all 0.3s ease-in-out 0s;
-  }
 
   a:not(.unstyled) {
-    @apply hover:border-sswRed hover:text-sswRed;
+    @apply underline transition duration-300 hover:border-sswRed hover:text-sswRed;
+  }
+
+  html {
+    @apply text-[14px] font-body;
   }
 
   html,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -326,12 +326,6 @@ module.exports = {
     require("@tailwindcss/typography"),
     require("@headlessui/tailwindcss")({ prefix: "ui" }),
 
-    plugin(function ({ addBase, theme }) {
-      addBase({
-        html: { fontSize: "14px", fontFamily: theme("fontFamily.body") },
-      });
-    }),
-
     // taken from https://github.com/tailwindlabs/tailwindcss/discussions/2156#discussioncomment-1283105
     plugin(function ({ addVariant, e }) {
       addVariant("not-first", ({ modifySelectors, separator }) => {


### PR DESCRIPTION
All links (unless `unstyled`) are now underlined and when hovered transition to red. Closes #196

![image](https://user-images.githubusercontent.com/600044/219997972-68ff0a33-ca24-4655-9079-0dde87f3b076.png)
